### PR TITLE
Fix typographic quotes in unsplash.ts

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,4 @@
-# These rules will change if you change your site’s custom domains or HTTPS settings
+# These rules will change if you change your site's custom domains or HTTPS settings
 
 # Redirect default Netlify subdomain to primary domain
 https://packer-cow-38488.netlify.com/* https://schultstefan.de/:splat 301!

--- a/src/unsplash.ts
+++ b/src/unsplash.ts
@@ -25,6 +25,6 @@ export default async function unsplash() {
     documentElement.style.setProperty('--unsplash-regular', `url(${unsplashRegular})`);
     documentElement.style.setProperty('--unsplash-blurry', `url(${blurry})`);
 
-    aside.innerHTML = `<a href="https://unsplash.com/photos/${id}?utm_source=Stefan%27s%20Photo%20App%20Example%0D%0ADemo&utm_medium=referral" rel=”nofollow”>Photo</a> by <a href="${unsplashProfil}?utm_source=Stefan%27s%20Photo%20App%20Example%0D%0ADemo&utm_medium=referral" rel=”nofollow”>${unsplashUser}</a> on <a href="https://unsplash.com/?utm_source=Stefan%27s%20Photo%20App%20Example%0D%0ADemo&utm_medium=referral" rel=”nofollow”>Unsplash</a>`;
+    aside.innerHTML = `<a href="https://unsplash.com/photos/${id}?utm_source=Stefan%27s%20Photo%20App%20Example%0D%0ADemo&utm_medium=referral" rel="nofollow">Photo</a> by <a href="${unsplashProfil}?utm_source=Stefan%27s%20Photo%20App%20Example%0D%0ADemo&utm_medium=referral" rel="nofollow">${unsplashUser}</a> on <a href="https://unsplash.com/?utm_source=Stefan%27s%20Photo%20App%20Example%0D%0ADemo&utm_medium=referral" rel="nofollow">Unsplash</a>`;
   }
 }


### PR DESCRIPTION
## Summary
- replace typographic quotes with standard quotes in Unsplash HTML snippet
- normalise apostrophe in `_redirects`

## Testing
- `npm test` *(fails: This template does not include a test runner by default)*

------
https://chatgpt.com/codex/tasks/task_e_6858677135c0832e9da53e066a49c36a