### PR TITLE
Fix build directory reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You will also see any lint errors in the console.
 
 ### npm run build
 
-Builds a static copy of your site to the `build/` folder.
+Builds a static copy of your site to the `dist/` folder (see `buildOptions.out` in `snowpack.config.js` if you want to change this location).
 Your app is ready to be deployed!
 
 **For the best production performance:** Add a build bundler plugin like [@snowpack/plugin-webpack](https://github.com/snowpackjs/snowpack/tree/main/plugins/plugin-webpack) or [snowpack-plugin-rollup-bundle](https://github.com/ParamagicDev/snowpack-plugin-rollup-bundle) to your `snowpack.config.json` config file.


### PR DESCRIPTION
## Summary
- fix reference to the build directory in README
- mention Snowpack config for changing output folder

## Testing
- `npm test` *(fails: This template does not include a test runner by default)*

------
https://chatgpt.com/codex/tasks/task_e_685867832e90832eac4973f7da2bcdcb