### PR TITLE
Remove debug logs from favicon generator

### DIFF
--- a/src/favicon.ts
+++ b/src/favicon.ts
@@ -13,7 +13,6 @@ export default async function createFavicon({
 }: Pick<ImageType['default'], 'color' | 'blurHash'>): Promise<string> {
   favicon = document.querySelector('[rel="shortcut icon"]');
   const pixels = decode(blurHash, 32, 32);
-  console.log({ pixels });
 
   const faviconSize = 32;
 
@@ -26,7 +25,6 @@ export default async function createFavicon({
   const img = document.createElement('img');
   if (favicon?.href) img.src = favicon.href;
   document.body.appendChild(canvas);
-  console.log(document.body.firstChild);
   document.body.insertBefore(canvas, document.body.firstChild);
   return new Promise((resolve) => {
     img.onload = () => {


### PR DESCRIPTION
## Summary
- remove leftover `console.log` calls in `src/favicon.ts`

## Testing
- `npm run lint`
- `npm test` *(fails: This template does not include a test runner by default.)*

------
https://chatgpt.com/codex/tasks/task_e_68586b437e84832e9d51eaea98118cac